### PR TITLE
Bump jQuery from 3.4.1 to 3.5.0 in /MVC Project/LibraryMSMVC

### DIFF
--- a/MVC Project/LibraryMSMVC/packages.config
+++ b/MVC Project/LibraryMSMVC/packages.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net472" />
   <package id="bootstrap" version="4.5.0" targetFramework="net472" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net472" />
   <package id="Font.Awesome" version="5.13.0" targetFramework="net472" />
   <package id="HelperMethods.HTMLHelper" version="1.0.0" targetFramework="net472" />
-  <package id="jQuery" version="3.4.1" targetFramework="net472" />
+  <package id="jQuery" version="3.5.0" targetFramework="net472" />
   <package id="jQuery.UI.Combined" version="1.12.1" targetFramework="net472" />
   <package id="jQuery.Validation" version="1.8.0.1" targetFramework="net472" />
   <package id="jQuery.Validation.Unobtrusive" version="2.0.20710.0" targetFramework="net472" />


### PR DESCRIPTION
Bumps jQuery from 3.4.1 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...